### PR TITLE
Fix genkernel install.

### DIFF
--- a/lib/phase3-build-root.sh
+++ b/lib/phase3-build-root.sh
@@ -137,7 +137,8 @@ eexec emerge $EMERGE_OPTS "sys-kernel/gentoo-sources"
 einfo "Installing genkernel..."
 
 if eoff "$GENTOO_SYSTEMD"; then
-    echo "sys-apps/util-linux static-libs" > /etc/portage/package.use/genkernel
+    echo "sys-kernel/genkernel -firmware" > /etc/portage/package.use/genkernel
+    echo "sys-apps/util-linux static-libs" >> /etc/portage/package.use/genkernel
     eexec emerge $EMERGE_OPTS sys-kernel/genkernel
 else
     eexec emerge $EMERGE_OPTS "sys-kernel/genkernel-next"


### PR DESCRIPTION
genkernel by default pulls in linux-firmware. Due to recent Gentoo changes to
the ACCEPT_LICENSE default, linux-firmware can no longer be installed without
manual intervention.

I can't think of anything that would need linux-firmware, so just avoid installing it. This has the side effect of slimming down the base install by about 400MB.