### PR TITLE
Fix for bug I've been finding

### DIFF
--- a/lib/phase2-prepare-root.sh
+++ b/lib/phase2-prepare-root.sh
@@ -138,7 +138,7 @@ fi
 einfo "Copying network options..."
 
 eexec rm -rf /mnt/gentoo/etc/resolv.conf
-eexec cp /etc/resolv.conf /mnt/gentoo/etc/
+eexec cp -L /etc/resolv.conf /mnt/gentoo/etc/
 
 ################################################################################
 


### PR DESCRIPTION
Sometimes /mnt/gentoo/etc/resolv.conf will be a dangling symlink, leading `cp -f` to not overwrite it, leading to a broken network configuration