### PR TITLE
latest-stage3-*.txt files are now PGP-signed

### DIFF
--- a/gentoo-ami-builder.sh
+++ b/gentoo-ami-builder.sh
@@ -18,6 +18,8 @@ source "$SCRIPT_DIR/lib/elib.sh"
 source "$SCRIPT_DIR/lib/disk.sh"
 # shellcheck source=lib/distfiles.sh
 source "$SCRIPT_DIR/lib/distfiles.sh"
+# shellcheck source=lib/gpg-verify.sh
+source "$SCRIPT_DIR/lib/gpg-verify.sh"
 
 APP_NAME="gentoo-ami-builder"
 APP_DESCRIPTION="Gentoo AMI Builder"

--- a/lib/bundle.sh
+++ b/lib/bundle.sh
@@ -88,6 +88,7 @@ $(
         eexec \
         eqexec \
         find_device \
+        gpg_verify \
         append_disk_part \
         find_disk1 \
         find_disk2 \

--- a/lib/distfiles.sh
+++ b/lib/distfiles.sh
@@ -44,11 +44,6 @@ download_distfile_safe() {
         exit 1
     fi
 
-    einfo "Verifying GPG signature..."
+    gpg_verify "$file.DIGESTS"
 
-    eexec gpg --keyserver hkps://keys.gentoo.org \
-        --recv-keys $GENTOO_GPG_KEYS
-
-    eexec gpg --verify "$file.DIGESTS" \
-        || edie "GPG signature verification failed."
 }

--- a/lib/gpg-verify.sh
+++ b/lib/gpg-verify.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# global GENTOO_GPG_KEYS
+# global GENTOO_GPG_KEYS_FETCHED
+
+gpg_verify() {
+    # global GENTOO_GPG_KEYS
+    # global GENTOO_GPG_KEYS_FETCHED
+
+    local file="$1"
+
+    # Mark these keys as trusted to avoid various gpg errors/warnings later.
+    if [ ! "$GENTOO_GPG_KEYS_FETCHED" = "1" ]; then
+      einfo "Fetching GPG keys..."
+      eexec gpg --keyserver hkps://keys.gentoo.org \
+        --recv-keys $GENTOO_GPG_KEYS \
+        || edie "Fetching GPG keys failed."
+      for KEY_ID in $GENTOO_GPG_KEYS ; do
+        (echo 5; echo y; echo save) |
+          eexec gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "$KEY_ID" trust
+      done
+      eexec gpg --check-trustdb
+      GENTOO_GPG_KEYS_FETCHED=1
+    fi
+
+    einfo "Verifying GPG signature for ${1} ..."
+
+    eexec gpg --verify "${1}" \
+        || edie "GPG signature verification failed."
+
+    true
+}

--- a/lib/phase2-prepare-root.sh
+++ b/lib/phase2-prepare-root.sh
@@ -93,8 +93,16 @@ einfo "Installing stage3..."
 
 eindent
 
-STAGE3_PATH_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/latest-stage3-$GENTOO_STAGE3.txt"
-STAGE3_PATH="$(curl -s "$STAGE3_PATH_URL" | grep -v "^#" | cut -d" " -f1)"
+LATEST_STAGE3="latest-stage3-$GENTOO_STAGE3.txt"
+STAGE3_PATH_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/$LATEST_STAGE3"
+STAGE3_PATH="$(curl -s -o $LATEST_STAGE3 "$STAGE3_PATH_URL")"
+test -s $LATEST_STAGE3 || edie "Fetching '$STAGE3_PATH_URL' failed"
+
+# N.B. are there any latest-stage3 files that are _not_ signed any more?
+gpg_verify $LATEST_STAGE3
+STAGE3_PATH="$(gpg -o - -d $LATEST_STAGE3 2>/dev/null | grep "^[0-9]" | cut -d" " -f1)"
+test -z "$STAGE3_PATH" && edie "Could not extract a valid path from '$STAGE3_PATH_URL'"
+
 STAGE3_URL="$GENTOO_MIRROR/releases/$GENTOO_ARCH/autobuilds/$STAGE3_PATH"
 STAGE3_FILE="$(basename "$STAGE3_URL")"
 


### PR DESCRIPTION
Verify the latest-stage3-*.txt file retrieved, and then extract from it the file path info we came for.

Since we're now gpg --verifying multiple times, break that out into its own helper library function, and bundle it.


Closes: https://github.com/sormy/gentoo-ami-builder/issues/22